### PR TITLE
Deploy AIOStack docs v0.2.2

### DIFF
--- a/charts/aiostack-docs/values.yaml
+++ b/charts/aiostack-docs/values.yaml
@@ -11,7 +11,7 @@ image:
   repository: asia-south1-docker.pkg.dev/aurva-gcp/aiostack-docs/aiostack-docs
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "v0.2.1"
+  tag: "v0.2.2"
 
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
Updates the aiostack-docs Helm chart to use the newly built docs image tag v0.2.2 from the merged website refresh.\n\nBuild run: https://github.com/aurva-io/AIOstack/actions/runs/25576645836

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated documentation service container image to the latest version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->