### PR TITLE
Bump docs image to v0.2.3

### DIFF
--- a/charts/aiostack-docs/values.yaml
+++ b/charts/aiostack-docs/values.yaml
@@ -11,7 +11,7 @@ image:
   repository: asia-south1-docker.pkg.dev/aurva-gcp/aiostack-docs/aiostack-docs
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "v0.2.2"
+  tag: "v0.2.3"
 
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
## Summary
- Update the aiostack-docs Helm chart image tag to v0.2.3.

## Validation
- BuildSite workflow triggered for v0.2.3: https://github.com/aurva-io/AIOstack/actions/runs/25590429268